### PR TITLE
Check auth when opening extension and before connecting to stream

### DIFF
--- a/sc-chrome-plugin/js/background.js
+++ b/sc-chrome-plugin/js/background.js
@@ -95,19 +95,6 @@ function setupNotifications() {
   username = localStorage['loginUsername'];
   password = localStorage['loginPassword'];
 
-  // check authentication on first connection attempt
-  if (attempts == 0) {
-    checkAuth((err) => {
-      if (err) {
-      streamSuspended = true;
-      spawnNotification(
-        'Authentication failed',
-        "Can't connect to notifications server. Login to reconnect."
-      )
-      }
-    })
-  }
-
   try {
     socket.unsubscribe();
   } catch (e) {
@@ -115,6 +102,18 @@ function setupNotifications() {
   }
 
   if (localStorage['loginValid'] == "true") {
+    // check authentication on first connection attempt
+    if (attempts == 0) {
+      checkAuth((err) => {
+        if (err) {
+        streamSuspended = true;
+        spawnNotification(
+          'Authentication failed',
+          "Can't connect to notifications server. Login to reconnect."
+        )
+        }
+      })
+    }
 
     streamSuspended = false;
     var auth = window.btoa(localStorage["loginUsername"] + ":" + localStorage["loginPassword"]);

--- a/sc-chrome-plugin/js/background.js
+++ b/sc-chrome-plugin/js/background.js
@@ -31,10 +31,82 @@ function getRandomArbitary (min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
+/**
+ * 
+ * @param {(err: boolean) => void} callback 
+ */
+function checkAuth(callback) {
+  log('[SCCE] Checking auth...')
+  // check authentication
+  var authUrl = localStorage["baseURL"] + "/customers/me";
+  var authReq = new XMLHttpRequest();
+  // This opens the request with username and password
+  authReq.open("HEAD", authUrl, false);
+  var auth = window.btoa(localStorage['loginUsername'] + ":" + localStorage['loginPassword']);
+  authReq.setRequestHeader('Authorization', 'Basic ' + auth)
+  // We wait untill something happens
+  authReq.onreadystatechange = function () {
+    if (authReq.readyState == 4) {
+      // If we get a 200 that means the credentials are correct
+      if (authReq.status === 200) {
+        callback(false);
+      } else {
+        // authentication failed - force relogin on next launch
+        localStorage['loginValid'] = null;
+        localStorage['loginPassword'] = null;
+        log('[SCCE] Auth failed... suspending stream')
+        callback(true);
+      }
+    }
+  };
+  authReq.send(null);
+}
+
+/**
+ * @param {string} title
+ * @param {string} body
+ * @param {function?} onClick 
+ */
+function spawnNotification(title, body, onClick) {
+  function notify() {
+    var notification = new Notification(title, {
+      body: body,
+      image: chrome.runtime.getURL("images/icon48.png"),
+      requireInteraction: !!onClick,
+    });
+    notification.onclick = onClick
+  }
+
+  if (("Notification" in window)) {
+    // Let's check whether notification permissions have already been granted
+    if (Notification.permission === "granted") { notify(); }
+    // Otherwise, we need to ask the user for permission
+    else if (Notification.permission !== "denied") {
+      Notification.requestPermission().then(function (permission) {
+        // If the user accepts, let's create a notification
+        if (permission === "granted") { notify(); }
+      });
+    }
+  }
+}
+
 function setupNotifications() {
 
   username = localStorage['loginUsername'];
   password = localStorage['loginPassword'];
+
+  // check authentication on first connection attempt
+  if (attempts == 0) {
+    checkAuth((err) => {
+      if (err) {
+      streamSuspended = true;
+      spawnNotification(
+        'Authentication failed',
+        "Can't connect to notifications server. Login to reconnect."
+      )
+      }
+    })
+  }
 
   try {
     socket.unsubscribe();
@@ -72,24 +144,18 @@ function setupNotifications() {
       log('[SCCE] Stream has dried up. (Error)');
       localStorage[localStorage['loginUsername'] + '_notificationConnection'] = false;
 
-      if (response.status == '401') {
-	// authentication failed - don't bother retrying
-        streamSuspended = true;
-      } else if (attempts < 5) {
+      if (attempts < 5) {
         log('[SCCE] Going to reconnect in 20 secconds. Try: ' + attempts)
         attempts += 1;
         setTimeout(function(){ if (!streamSuspended) {setupNotifications()}; },20000);
       } else if (!streamSuspended) {
         log('[SCCE] Max attempts reached.');
-        var errorNotification = webkitNotifications.createNotification('images/icon48.png', 'Connection Error', "Can't connect to the notifications server. Click here to reconnect.");
+        spawnNotification(
+          "Connection Error",
+          "Can't connect to the notifications server. Click here to reconnect.",
+          function(){ attempts = 0; setupNotifications(); }
+        );
         streamSuspended = true;
-        errorNotification.onclick = function(){
-          attempts = 0;
-          errorNotification.cancel();
-          setupNotifications();
-        }
-
-        errorNotification.show();
       }
     };
 

--- a/sc-chrome-plugin/js/main.js
+++ b/sc-chrome-plugin/js/main.js
@@ -1638,17 +1638,40 @@ $(document).ready(function() {
   // Check if there is a logged in or show welcome
   if ( localStorage['loginUsername'] == null ) {
     showWelcome();
+    $('#splashScreen').hide();
   } else if ( localStorage["loginValid"] != 'true' ) {
     showLogin();
+    $('#splashScreen').hide();
   } else {
-    if ( localStorage[localStorage['loginUsername'] + '_loginSetup'] == 'done' ) {
-      showDialer();
-    } else {
-      // If the user has not completed the setup take them back to the settings page
-      showSettings();
-      // Hide menu prevents users from clicking off the page
-      hideMenu();
+    hideMenu();
+    var authUrl = localStorage['baseURL'] + '/customers/me';
+    var checkAuth = new XMLHttpRequest();
+    // This opens the request with username and password
+    checkAuth.open("HEAD", authUrl, false);
+    var auth = window.btoa(localStorage['loginUsername'] + ":" + localStorage['loginPassword']);
+    checkAuth.setRequestHeader('Authorization', 'Basic ' + auth);
+    checkAuth.onreadystatechange=function() {
+      if (checkAuth.readyState==4) {
+        $('#splashScreen').hide();
+        if (checkAuth.status === 200) {
+          if ( localStorage[localStorage['loginUsername'] + '_loginSetup'] == 'done' ) {
+            showDialer();
+          } else {
+            // If the user has not completed the setup take them back to the settings page
+            showSettings();
+            // Hide menu prevents users from clicking off the page
+            hideMenu();
+          }
+        } else {
+          // invalid auth
+          localStorage['loginValid'] = null;
+          localStorage['loginPassword'] = null;
+          showLogin();
+        }
+      }
     }
+    // This sends the actual request to the server, but we are not posting any data so we send null
+    checkAuth.send(null);
   }
 
 });

--- a/sc-chrome-plugin/main.html
+++ b/sc-chrome-plugin/main.html
@@ -12,6 +12,10 @@
 
   <body>
 
+    <div id="splashScreen">
+      <img src='images/icon48.png' alt='logo' />
+    </div>
+
     <div id="mainMenu" class="navbar navbar-static-top navbar-inverse">
       <div class="navbar-inner">
         <ul class="nav pull-right">
@@ -379,7 +383,7 @@
 
     <div id="loadingModal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
       <div class="modal-body">
-        <p class="lead">Loading…</p>
+        <p class="lead">Loading...</p>
       </div>
     </div>
 

--- a/sc-chrome-plugin/style.css
+++ b/sc-chrome-plugin/style.css
@@ -59,6 +59,20 @@ body {
   margin-top: 100px;
 }
 
+#splashScreen {
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  z-index: 10;
+  background: white;
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  pointer-events: none;
+}
+
 #SMSConversationTitle {
   color: #6F6F6F;
   font-size: 12px;


### PR DESCRIPTION
`background.js`
  - Manually check authentication on the first connection attempt to `/stream`, as the check for `response.status == 401` was not working. (Atmosphere overwrites the status with `0`)
  - Also fix deprecated `webkitNotifications` API, replaced with new Notification API

`main.js`
  - Check authentication whenever the extension popup is loaded, if auth fails then redirect to login page, otherwise continue as before